### PR TITLE
2.6.108

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wlan-cloud-owprov-ui",
-  "version": "2.6.107",
+  "version": "2.6.108",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wlan-cloud-owprov-ui",
-      "version": "2.6.107",
+      "version": "2.6.108",
       "license": "ISC",
       "dependencies": {
         "@chakra-ui/icons": "^1.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wlan-cloud-owprov-ui",
-  "version": "2.6.108",
+  "version": "2.6.109",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wlan-cloud-owprov-ui",
-      "version": "2.6.108",
+      "version": "2.6.109",
       "license": "ISC",
       "dependencies": {
         "@chakra-ui/icons": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wlan-cloud-owprov-ui",
-  "version": "2.6.107",
+  "version": "2.6.108",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wlan-cloud-owprov-ui",
-  "version": "2.6.108",
+  "version": "2.6.109",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/components/Tables/InventoryTable/ConfigurationPushModal/index.js
+++ b/src/components/Tables/InventoryTable/ConfigurationPushModal/index.js
@@ -29,7 +29,7 @@ const ConfigurationPushModal = ({ isOpen, onClose, pushResult }) => {
         <ModalBody>
           <Alert status={pushResult?.errorCode !== 0 ? 'error' : 'success'}>
             <AlertIcon />
-            {pushResult?.result?.errorCode !== 0
+            {pushResult?.errorCode !== 0
               ? t('configurations.push_configuration_explanation', {
                   code: pushResult?.errorCode ?? 0,
                 })

--- a/src/pages/ConfigurationPage/ConfigurationCard/ConfigurationSectionsCard/RadiosSection/SingleRadio.js
+++ b/src/pages/ConfigurationPage/ConfigurationCard/ConfigurationSectionsCard/RadiosSection/SingleRadio.js
@@ -51,6 +51,7 @@ const SingleRadio = ({ editing, index, remove }) => {
             label="bandwidth"
             definitionKey="radio.bandwidth"
             isDisabled={!editing}
+            isInt
             isRequired
             options={[
               { value: 5, label: '5' },


### PR DESCRIPTION
- Fix for display of configuration push to a device result
- Configuration fix: radios[x].bandwidth now an integer instead of a string