### PR TITLE
[WIFI-9797] SSID.roaming.domain-identifier is not required anymore

### DIFF
--- a/src/pages/ConfigurationPage/ConfigurationCard/ConfigurationSectionsCard/InterfaceSection/SingleInterface/SsidList/Roaming/Roaming.tsx
+++ b/src/pages/ConfigurationPage/ConfigurationCard/ConfigurationSectionsCard/InterfaceSection/SingleInterface/SsidList/Roaming/Roaming.tsx
@@ -44,7 +44,7 @@ const RoamingForm: React.FC<Props> = ({ editing, namePrefix, isEnabled, onToggle
           label="domain-identifier"
           definitionKey="interface.ssid.roaming.domain-identifier"
           isDisabled={!editing}
-          isRequired
+          emptyIsUndefined
         />
         <StringField
           name={`${namePrefix}.pmk-r0-key-holder`}

--- a/src/pages/ConfigurationPage/ConfigurationCard/ConfigurationSectionsCard/InterfaceSection/interfacesConstants.js
+++ b/src/pages/ConfigurationPage/ConfigurationCard/ConfigurationSectionsCard/InterfaceSection/interfacesConstants.js
@@ -198,14 +198,13 @@ export const INTERFACE_SSID_ROAMING_SCHEMA = (t, useDefault = false) => {
     .shape({
       'message-exchange': string().required(t('form.required')).default('ds'),
       'generate-psk': bool().required(t('form.required')).default(false),
-      'domain-identifier': string().required(t('form.required')).default(''),
+      'domain-identifier': string().default(undefined),
       'pmk-r0-key-holder': string().default(undefined),
       'pmk-r1-key-holder': string().default(undefined),
     })
     .default({
       'message-exchange': 'ds',
       'generate-psk': false,
-      'domain-identifier': '',
     });
 
   return useDefault ? shape : shape.nullable().default(undefined);


### PR DESCRIPTION
Signed-off-by: Charles <charles.bourque96@gmail.com>